### PR TITLE
Recognize and ignore already handled updates from FB

### DIFF
--- a/lib/redis.py
+++ b/lib/redis.py
@@ -1,0 +1,12 @@
+import os
+import redis as redis_
+
+
+HANDLED_UPDATES_FB = 'handled_updates_fb'
+
+try:
+    REDIS_URL = os.environ['REDIS_URL']
+    redis = redis_.StrictRedis.from_url(REDIS_URL)
+
+except KeyError:
+    redis = None

--- a/worker/cleanup.py
+++ b/worker/cleanup.py
@@ -1,0 +1,16 @@
+from time import time
+
+from mrq.context import log
+from worker import BaseTask
+
+from lib.redis import redis, HANDLED_UPDATES_FB
+
+FB_UPDATES_CACHE_TIME = 60 * 60
+
+
+class HandledUpdates(BaseTask):
+
+    def run(self, params):
+        max_time = time() - FB_UPDATES_CACHE_TIME
+        num = redis.zremrangebyscore(HANDLED_UPDATES_FB, '-inf', max_time)
+        log.info(f'Deleted {num} already handled message IDs')

--- a/worker/mrq-config.py
+++ b/worker/mrq-config.py
@@ -31,6 +31,11 @@ SCHEDULER_TASKS = [
         'params': {},
         'interval': 60 * 5,
     },
+    {
+        'path': 'cleanup.HandledUpdates',
+        'params': {},
+        'interval': 60 * 5,
+    },
 
     # MRQ maintenance jobs
 


### PR DESCRIPTION
:sparkles:

Designed after [this recommendation](https://github.com/antirez/redis/issues/135#issuecomment-2361996), we put every message ID into a sorted redis set with the current time as the sorting key. If the message ID is already present, it's a retry.

For button presses, the message ID is composed from the PSID and timestamp (does not change between FB retries) as they have no `message` and therefore no `mid` attribute.

Once every 5 minutes, we delete all message IDs that are older than 1 hour.